### PR TITLE
remove-seed-step

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ Create a local SQLite database and run migrations.
 npx prisma migrate dev --name init
 ```
 
-Seed the database with the sample data from [`prisma/seed.js`](./prisma/seed.js).
-
-```
-npx prisma db seed
-```
-
 ### 5. Start the app
 
 ```


### PR DESCRIPTION
Changes:
- Remove the seed step from the instructions. It isn't needed as `npx prisma migrate dev --name init` already seeds the database. Running the seed step again just causes errors.